### PR TITLE
Add Guardian Times system

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -7,6 +7,7 @@
     {% if role == 'admin' %}
       <a href="{{ url_for('add_user') }}" class="btn btn-kingdom btn-lg">Add Users</a>
       <a href="{{ url_for('dkp_management') }}" class="btn btn-kingdom btn-lg">DKP</a>
+      <a href="{{ url_for('guardians') }}" class="btn btn-kingdom btn-lg">Guardians</a>
     {% endif %}
   </div>
 {% endblock %}

--- a/templates/guardian_times.html
+++ b/templates/guardian_times.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Guardians Map</h2>
+{% if map_image %}
+<div class="mb-4 text-center">
+    <img src="{{ url_for('uploaded_file', filename=map_image) }}" class="img-fluid" alt="Guardians Map">
+</div>
+{% endif %}
+{% if entries %}
+<div class="table-responsive">
+<table class="table table-dark table-striped table-hover">
+    <thead>
+        <tr>
+            <th>Site Type</th>
+            <th>Alliance</th>
+            <th>Time 1 (UTC)</th>
+            <th>Time 2 (UTC)</th>
+            <th>X</th>
+            <th>Y</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for e in entries %}
+        <tr>
+            <td>{{ e['site_type'] }}</td>
+            <td>{{ e['alliance'] }}</td>
+            <td>{{ e['time1'] }}</td>
+            <td>{{ e['time2'] }}</td>
+            <td>{{ e['x_coord'] }}</td>
+            <td>{{ e['y_coord'] }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+</div>
+{% else %}
+<p>No guardian times recorded.</p>
+{% endif %}
+<a href="{{ url_for('home') }}" class="btn btn-secondary mt-3">Back to Home</a>
+{% endblock %}

--- a/templates/guardians.html
+++ b/templates/guardians.html
@@ -1,0 +1,96 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Guardians Management</h2>
+<div class="row">
+    <div class="col-md-6">
+        <div class="card bg-dark text-white mb-3">
+            <div class="card-body">
+                <h5 class="card-title">Upload Map</h5>
+                <form method="post" enctype="multipart/form-data">
+                    <input type="hidden" name="form_type" value="map">
+                    <div class="mb-3">
+                        <input type="file" class="form-control" name="map_image" accept="image/*" required>
+                    </div>
+                    <button type="submit" class="btn btn-kingdom">Upload</button>
+                </form>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="card bg-dark text-white mb-3">
+            <div class="card-body">
+                <h5 class="card-title">Add Guardian Time</h5>
+                <form method="post">
+                    <input type="hidden" name="form_type" value="time">
+                    <div class="mb-2">
+                        <label class="form-label">Site Type</label>
+                        <select class="form-select" name="site_type" required>
+                            <option>Crusader Camp</option>
+                            <option>Crusader Fortress</option>
+                            <option>Circle</option>
+                            <option>Hieron</option>
+                            <option>Tempest Sanctuary</option>
+                            <option>The Great Ziggurat</option>
+                        </select>
+                    </div>
+                    <div class="mb-2">
+                        <label class="form-label">Alliance</label>
+                        <select class="form-select" name="alliance" required>
+                            <option>EK</option>
+                            <option>EG</option>
+                            <option>ED</option>
+                            <option>EE</option>
+                        </select>
+                    </div>
+                    <div class="mb-2">
+                        <label class="form-label">Time 1 (UTC)</label>
+                        <input type="text" class="form-control" name="time1" required>
+                    </div>
+                    <div class="mb-2">
+                        <label class="form-label">Time 2 (UTC)</label>
+                        <input type="text" class="form-control" name="time2" required>
+                    </div>
+                    <div class="mb-2">
+                        <label class="form-label">X Coordinate</label>
+                        <input type="text" class="form-control" name="x_coord" required>
+                    </div>
+                    <div class="mb-2">
+                        <label class="form-label">Y Coordinate</label>
+                        <input type="text" class="form-control" name="y_coord" required>
+                    </div>
+                    <button type="submit" class="btn btn-kingdom">Add</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% if entries %}
+<div class="table-responsive">
+<table class="table table-dark table-striped table-hover">
+    <thead>
+        <tr>
+            <th>Site Type</th>
+            <th>Alliance</th>
+            <th>Time 1</th>
+            <th>Time 2</th>
+            <th>X</th>
+            <th>Y</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for e in entries %}
+        <tr>
+            <td>{{ e['site_type'] }}</td>
+            <td>{{ e['alliance'] }}</td>
+            <td>{{ e['time1'] }}</td>
+            <td>{{ e['time2'] }}</td>
+            <td>{{ e['x_coord'] }}</td>
+            <td>{{ e['y_coord'] }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+</div>
+{% endif %}
+<a href="{{ url_for('dashboard') }}" class="btn btn-secondary mt-3">Back to Dashboard</a>
+{% endblock %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -32,6 +32,15 @@
                 </div>
             </div>
         </div>
+        <div class="col-md-4 mb-3">
+            <div class="card bg-dark text-white h-100">
+                <div class="card-body text-center">
+                    <h5 class="card-title">Guardian Times</h5>
+                    <p class="card-text">View a map and list of the guardian times for all holy sites in the lost kingdom.</p>
+                    <a href="{{ url_for('guardian_times') }}" class="btn btn-kingdom">Guardian Times</a>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- create guardian tables in DB and seed defaults
- implement Guardian Times viewing and admin upload/entry
- expose new routes `/guardian_times` and `/guardians`
- add Guardians button in dashboard for admins
- add Guardian Times card on home page
- add templates for guardian management and viewing

## Testing
- `python -m py_compile app.py`
- `pip install flake8` *(fails: network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_684ed4fea704832f9a062154f8271fa6